### PR TITLE
"jre" source includes imports of jsinterop-annotation classes POM fix

### DIFF
--- a/maven/jre/pom.xml
+++ b/maven/jre/pom.xml
@@ -49,11 +49,18 @@
     </plugins>
   </build>
   <dependencies>
-    <!-- may not be required here, but has to be lumped in to the j2cl bytecode classpath -->
+    <dependency>
+      <groupId>com.google.jsinterop</groupId>
+      <artifactId>jsinterop-annotations</artifactId>
+      <version>2.0.0</version>
+    </dependency>
+      
+      <!-- may not be required here, but has to be lumped in to the j2cl bytecode classpath -->
     <dependency>
       <groupId>com.vertispan.j2cl</groupId>
       <artifactId>gwt-internal-annotations</artifactId>
       <version>${project.version}</version>
     </dependency>
+      
   </dependencies>
 </project>


### PR DESCRIPTION
This JRE includes many uses of annotations present in jsinterop-annotation. The current vertispan/j2cl-maven-plugin auto adds this missing annotation to all classpaths so the missing jar is not a problem.

However in the interest of correctness and so that tools show the correct dependency graph this jar really should be present in this POM.